### PR TITLE
Refactor NSS crate

### DIFF
--- a/nss_simpleauthd/src/config.rs
+++ b/nss_simpleauthd/src/config.rs
@@ -1,0 +1,13 @@
+lazy_static::lazy_static! {
+    pub static ref CFG: NssConfig = {
+        let mut cfg: NssConfig =  toml::from_slice(std::fs::read(authd::find_config_dir().map(|cd| cd.join("nss_simpleauthd.toml")).expect("no nss_simpleauthd.toml found!")).unwrap().as_slice()).unwrap();
+        cfg.cert = shellexpand::full(&cfg.cert).unwrap().to_string();
+        cfg
+    };
+}
+
+#[derive(serde::Deserialize)]
+pub struct NssConfig {
+    pub host: authd::SocketName,
+    pub cert: String,
+}

--- a/nss_simpleauthd/src/ffi.rs
+++ b/nss_simpleauthd/src/ffi.rs
@@ -1,0 +1,17 @@
+use std::sync::Mutex;
+
+use libnss::group::Group;
+use libnss::interop::Iterator;
+use libnss::passwd::Passwd;
+use libnss::shadow::Shadow;
+
+// Required by nss bindings
+lazy_static::lazy_static! {
+    static ref PASSWD_ITERATOR: Mutex<Iterator<Passwd>> = Mutex::new(Iterator::<Passwd>::new());
+    static ref GROUP_ITERATOR: Mutex<Iterator<Group>> = Mutex::new(Iterator::<Group>::new());
+    static ref SHADOW_ITERATOR: Mutex<Iterator<Shadow>> = Mutex::new(Iterator::<Shadow>::new());
+}
+
+mod group;
+mod passwd;
+mod shadow;

--- a/nss_simpleauthd/src/ffi/group.rs
+++ b/nss_simpleauthd/src/ffi/group.rs
@@ -1,0 +1,68 @@
+use std::ffi::CStr;
+use std::str;
+
+use libc::c_int;
+use libnss::{
+    group::{CGroup, GroupHooks},
+    interop::Response,
+};
+
+use crate::{ffi::GROUP_ITERATOR, AuthdGroup};
+
+#[no_mangle]
+extern "C" fn _nss_simpleauthd_setgrent() -> c_int {
+    let mut iter = GROUP_ITERATOR.lock().unwrap();
+
+    let status = match AuthdGroup::get_all_entries() {
+        Response::Success(entries) => iter.open(entries),
+        response => response.to_status(),
+    };
+
+    status as c_int
+}
+
+#[no_mangle]
+extern "C" fn _nss_simpleauthd_endgrent() -> c_int {
+    let mut iter = GROUP_ITERATOR.lock().unwrap();
+    iter.close() as c_int
+}
+
+#[no_mangle]
+unsafe extern "C" fn _nss_simpleauthd_getgrent_r(
+    result: *mut CGroup,
+    buf: *mut libc::c_char,
+    buflen: libc::size_t,
+    errnop: *mut c_int,
+) -> c_int {
+    let mut iter = GROUP_ITERATOR.lock().unwrap();
+    iter.next().to_c(result, buf, buflen, errnop) as c_int
+}
+
+#[no_mangle]
+unsafe extern "C" fn _nss_simpleauthd_getgrgid_r(
+    uid: libc::uid_t,
+    result: *mut CGroup,
+    buf: *mut libc::c_char,
+    buflen: libc::size_t,
+    errnop: *mut c_int,
+) -> c_int {
+    AuthdGroup::get_entry_by_gid(uid).to_c(result, buf, buflen, errnop) as c_int
+}
+
+#[no_mangle]
+unsafe extern "C" fn nss_simpleauthd_getgrnam_r(
+    name_: *const libc::c_char,
+    result: *mut CGroup,
+    buf: *mut libc::c_char,
+    buflen: libc::size_t,
+    errnop: *mut c_int,
+) -> c_int {
+    let cstr = CStr::from_ptr(name_);
+
+    let response = match str::from_utf8(cstr.to_bytes()) {
+        Ok(name) => AuthdGroup::get_entry_by_name(name.to_string()),
+        Err(_) => Response::NotFound,
+    };
+
+    response.to_c(result, buf, buflen, errnop) as c_int
+}

--- a/nss_simpleauthd/src/ffi/passwd.rs
+++ b/nss_simpleauthd/src/ffi/passwd.rs
@@ -1,0 +1,67 @@
+use libc::c_int;
+use libnss::interop::Response;
+use libnss::passwd::{CPasswd, PasswdHooks};
+
+use std::ffi::CStr;
+use std::str;
+
+use crate::ffi::PASSWD_ITERATOR;
+use crate::AuthdPasswd;
+
+#[no_mangle]
+extern "C" fn _nss_simpleauthd_setpwent() -> c_int {
+    let mut iter = PASSWD_ITERATOR.lock().unwrap();
+
+    let status = match AuthdPasswd::get_all_entries() {
+        Response::Success(entries) => iter.open(entries),
+        response => response.to_status(),
+    };
+
+    status as c_int
+}
+
+#[no_mangle]
+extern "C" fn _nss_simpleauthd_endpwent() -> c_int {
+    let mut iter = PASSWD_ITERATOR.lock().unwrap();
+    iter.close() as c_int
+}
+
+#[no_mangle]
+unsafe extern "C" fn _nss_simpleauthd_getpwent_r(
+    result: *mut CPasswd,
+    buf: *mut libc::c_char,
+    buflen: libc::size_t,
+    errnop: *mut c_int,
+) -> c_int {
+    let mut iter = PASSWD_ITERATOR.lock().unwrap();
+    iter.next().to_c(result, buf, buflen, errnop) as c_int
+}
+
+#[no_mangle]
+unsafe extern "C" fn _nss_simpleauthd_getpwuid_r(
+    uid: libc::uid_t,
+    result: *mut CPasswd,
+    buf: *mut libc::c_char,
+    buflen: libc::size_t,
+    errnop: *mut c_int,
+) -> c_int {
+    AuthdPasswd::get_entry_by_uid(uid).to_c(result, buf, buflen, errnop) as c_int
+}
+
+#[no_mangle]
+unsafe extern "C" fn nss_simpleauthd_getpwnam_r(
+    name_: *const libc::c_char,
+    result: *mut CPasswd,
+    buf: *mut libc::c_char,
+    buflen: libc::size_t,
+    errnop: *mut c_int,
+) -> c_int {
+    let cstr = CStr::from_ptr(name_);
+
+    let response = match str::from_utf8(cstr.to_bytes()) {
+        Ok(name) => AuthdPasswd::get_entry_by_name(name.to_string()),
+        Err(_) => Response::NotFound,
+    };
+
+    response.to_c(result, buf, buflen, errnop) as c_int
+}

--- a/nss_simpleauthd/src/ffi/shadow.rs
+++ b/nss_simpleauthd/src/ffi/shadow.rs
@@ -1,0 +1,57 @@
+use std::ffi::CStr;
+use std::str;
+
+use libc::c_int;
+use libnss::{
+    interop::Response,
+    shadow::{CShadow, ShadowHooks},
+};
+
+use crate::{ffi::SHADOW_ITERATOR, AuthdShadow};
+
+#[no_mangle]
+extern "C" fn _nss_simpleauthd_setspent() -> c_int {
+    let mut iter = SHADOW_ITERATOR.lock().unwrap();
+
+    let status = match AuthdShadow::get_all_entries() {
+        Response::Success(entries) => iter.open(entries),
+        response => response.to_status(),
+    };
+
+    status as c_int
+}
+
+#[no_mangle]
+extern "C" fn _nss_simpleauthd_endspent() -> c_int {
+    let mut iter = SHADOW_ITERATOR.lock().unwrap();
+    iter.close() as c_int
+}
+
+#[no_mangle]
+unsafe extern "C" fn _nss_simpleauthd_getspent_r(
+    result: *mut CShadow,
+    buf: *mut libc::c_char,
+    buflen: libc::size_t,
+    errnop: *mut c_int,
+) -> c_int {
+    let mut iter = SHADOW_ITERATOR.lock().unwrap();
+    iter.next().to_c(result, buf, buflen, errnop) as c_int
+}
+
+#[no_mangle]
+unsafe extern "C" fn nss_simpleauthd_getspnam_r(
+    name_: *const libc::c_char,
+    result: *mut CShadow,
+    buf: *mut libc::c_char,
+    buflen: libc::size_t,
+    errnop: *mut c_int,
+) -> c_int {
+    let cstr = CStr::from_ptr(name_);
+
+    let response = match str::from_utf8(cstr.to_bytes()) {
+        Ok(name) => AuthdShadow::get_entry_by_name(name.to_string()),
+        Err(_) => Response::NotFound,
+    };
+
+    response.to_c(result, buf, buflen, errnop) as c_int
+}

--- a/nss_simpleauthd/src/group.rs
+++ b/nss_simpleauthd/src/group.rs
@@ -1,0 +1,47 @@
+use authd::types::ToNSS;
+use futures::executor::block_on;
+use libnss::{
+    group::{Group, GroupHooks},
+    interop::Response,
+};
+use tarpc::context;
+
+use crate::{AuthdGroup, RPC};
+
+impl GroupHooks for AuthdGroup {
+    fn get_all_entries() -> Response<Vec<Group>> {
+        let mut cl = RPC.lock().unwrap();
+        cl.with_client(
+            |client| match block_on(client.get_all_groups(context::current())) {
+                Ok(passwds) => Response::Success(passwds.into_iter().map(|x| x.to_nss()).collect()),
+                Err(_e) => Response::Unavail,
+            },
+        )
+    }
+
+    fn get_entry_by_gid(gid: libc::gid_t) -> libnss::interop::Response<libnss::group::Group> {
+        let mut cl = RPC.lock().unwrap();
+        cl.with_client(
+            |client| match block_on(client.get_group_by_gid(context::current(), gid)) {
+                Ok(passwd) => match passwd {
+                    Some(p) => Response::Success(p.to_nss()),
+                    None => Response::NotFound,
+                },
+                Err(_e) => Response::Unavail,
+            },
+        )
+    }
+
+    fn get_entry_by_name(name: String) -> libnss::interop::Response<libnss::group::Group> {
+        let mut cl = RPC.lock().unwrap();
+        cl.with_client(|client| {
+            match block_on(client.get_group_by_name(context::current(), name)) {
+                Ok(passwd) => match passwd {
+                    Some(p) => Response::Success(p.to_nss()),
+                    None => Response::NotFound,
+                },
+                Err(_e) => Response::Unavail,
+            }
+        })
+    }
+}

--- a/nss_simpleauthd/src/lib.rs
+++ b/nss_simpleauthd/src/lib.rs
@@ -1,16 +1,25 @@
-use authd::types::ToNSS;
-use futures::executor::block_on;
-use libc::c_int;
-use libnss::group::{CGroup, Group, GroupHooks};
-use libnss::interop::{Iterator, Response};
-use libnss::passwd::{CPasswd, Passwd};
-use std::ffi::CStr;
-use std::str;
-use std::sync::{Arc, Mutex, MutexGuard};
+mod config;
+mod ffi;
+mod group;
+mod passwd;
+mod shadow;
+
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
-use tarpc::context;
 use tokio::runtime::{self, Runtime};
 use tokio::time::sleep_until;
+use trust_dns_resolver::TokioAsyncResolver;
+
+use crate::config::CFG;
+
+lazy_static::lazy_static! {
+    static ref RPC: Mutex<ClientAccessControl> = Mutex::new(ClientAccessControl::default());
+    static ref RT: Runtime = runtime::Builder::new_multi_thread().worker_threads(2).enable_io().enable_time().build().expect("could not initialize tokio runtime");
+}
+
+struct AuthdPasswd;
+struct AuthdShadow;
+struct AuthdGroup;
 
 #[derive(Default)]
 struct ClientAccessControl {
@@ -18,19 +27,13 @@ struct ClientAccessControl {
     latest_ts: Arc<Mutex<Option<Instant>>>,
 }
 
-#[derive(serde::Deserialize)]
-struct NssConfig {
-    host: authd::SocketName,
-    cert: String,
-}
-
 impl ClientAccessControl {
     fn with_client<O>(&mut self, f: impl FnOnce(&mut authd::rpc::AuthdClient) -> O) -> O {
-        use trust_dns_resolver::TokioAsyncResolver;
         let _guard = RT.enter();
         let mut lts = self.latest_ts.lock().unwrap();
         *lts = Some(std::time::Instant::now() + Duration::from_secs(30));
-        let cl = self.client.clone();
+
+        let client = self.client.clone();
         let latest_ts = self.latest_ts.clone();
         tokio::spawn(async move {
             loop {
@@ -38,11 +41,7 @@ impl ClientAccessControl {
                 sleep_until(dur).await;
                 // make sure it wasn't moved forward while we were sleeping
                 if latest_ts.lock().unwrap().unwrap_or(Instant::now()) < Instant::now() {
-                    *cl.lock().unwrap() = None;
-                    #[cfg(debug_assertions)]
-                    eprintln!(
-                        "nss_simpleauthd: ClientAccessControl: client timed out, closing connection."
-                    );
+                    *client.lock().unwrap() = None;
                     break;
                 }
             }
@@ -62,10 +61,12 @@ impl ClientAccessControl {
             }
             authd::SocketName::Addr(sa) => Some(*sa),
         };
+
         eprintln!(
             "nss_simpleauthd: ClientAccessControl: connecting to {:?}",
             final_sockaddr
         );
+
         let mut client = self.client.lock().unwrap();
         if client.is_none() {
             *client = Some(
@@ -79,286 +80,4 @@ impl ClientAccessControl {
         }
         f(client.as_mut().unwrap())
     }
-}
-
-lazy_static::lazy_static! {
-    static ref PASSWD_ITERATOR: Mutex<Iterator<Passwd>> = Mutex::new(Iterator::<Passwd>::new());
-    static ref GROUP_ITERATOR: Mutex<Iterator<Group>> = Mutex::new(Iterator::<Group>::new());
-    static ref SHADOW_ITERATOR: Mutex<Iterator<libnss::shadow::Shadow>> = Mutex::new(Iterator::<libnss::shadow::Shadow>::new());
-
-    static ref RPC: Mutex<ClientAccessControl> = Mutex::new(ClientAccessControl::default());
-    static ref RT: Runtime = runtime::Builder::new_multi_thread().worker_threads(2).enable_io().enable_time().build().expect("could not initialize tokio runtime");
-    static ref CFG: NssConfig = {
-        let mut cfg: NssConfig =  toml::from_slice(std::fs::read(authd::find_config_dir().map(|cd| cd.join("nss_simpleauthd.toml")).expect("no nss_simpleauthd.toml found!")).unwrap().as_slice()).unwrap();
-        cfg.cert = shellexpand::full(&cfg.cert).unwrap().to_string();
-        cfg
-    };
-}
-
-struct CauthdPasswd;
-impl libnss::passwd::PasswdHooks for CauthdPasswd {
-    fn get_all_entries() -> libnss::interop::Response<Vec<libnss::passwd::Passwd>> {
-        let mut cl = RPC.lock().unwrap();
-        cl.with_client(
-            |client| match block_on(client.get_all_passwd(context::current())) {
-                Ok(passwds) => Response::Success(passwds.into_iter().map(|x| x.to_nss()).collect()),
-                Err(_e) => Response::Unavail,
-            },
-        )
-    }
-
-    fn get_entry_by_uid(uid: libc::uid_t) -> libnss::interop::Response<libnss::passwd::Passwd> {
-        let mut cl = RPC.lock().unwrap();
-        cl.with_client(
-            |client| match block_on(client.get_passwd_by_uid(context::current(), uid)) {
-                Ok(passwd) => match passwd {
-                    Some(p) => Response::Success(p.to_nss()),
-                    None => Response::NotFound,
-                },
-                Err(_e) => Response::Unavail,
-            },
-        )
-    }
-
-    fn get_entry_by_name(name: String) -> libnss::interop::Response<libnss::passwd::Passwd> {
-        let mut cl = RPC.lock().unwrap();
-        cl.with_client(|client| {
-            match block_on(client.get_passwd_by_name(context::current(), name)) {
-                Ok(passwd) => match passwd {
-                    Some(p) => Response::Success(p.to_nss()),
-                    None => Response::NotFound,
-                },
-                Err(_e) => Response::Unavail,
-            }
-        })
-    }
-}
-struct CauthdShadow;
-impl libnss::shadow::ShadowHooks for CauthdShadow {
-    fn get_all_entries() -> libnss::interop::Response<Vec<libnss::shadow::Shadow>> {
-        let mut cl = RPC.lock().unwrap();
-        cl.with_client(
-            |client| match block_on(client.get_all_shadow(context::current())) {
-                Ok(passwds) => Response::Success(passwds.into_iter().map(|x| x.to_nss()).collect()),
-                Err(_e) => Response::Unavail,
-            },
-        )
-    }
-
-    fn get_entry_by_name(name: String) -> libnss::interop::Response<libnss::shadow::Shadow> {
-        let mut cl = RPC.lock().unwrap();
-        cl.with_client(|client| {
-            match block_on(client.get_shadow_by_name(context::current(), name)) {
-                Ok(passwd) => match passwd {
-                    Some(p) => Response::Success(p.to_nss()),
-                    None => Response::NotFound,
-                },
-                Err(_e) => Response::Unavail,
-            }
-        })
-    }
-}
-
-struct CauthdGroup;
-impl libnss::group::GroupHooks for CauthdGroup {
-    fn get_all_entries() -> libnss::interop::Response<Vec<libnss::group::Group>> {
-        let mut cl = RPC.lock().unwrap();
-        cl.with_client(
-            |client| match block_on(client.get_all_groups(context::current())) {
-                Ok(passwds) => Response::Success(passwds.into_iter().map(|x| x.to_nss()).collect()),
-                Err(_e) => Response::Unavail,
-            },
-        )
-    }
-
-    fn get_entry_by_gid(gid: libc::gid_t) -> libnss::interop::Response<libnss::group::Group> {
-        let mut cl = RPC.lock().unwrap();
-        cl.with_client(
-            |client| match block_on(client.get_group_by_gid(context::current(), gid)) {
-                Ok(passwd) => match passwd {
-                    Some(p) => Response::Success(p.to_nss()),
-                    None => Response::NotFound,
-                },
-                Err(_e) => Response::Unavail,
-            },
-        )
-    }
-
-    fn get_entry_by_name(name: String) -> libnss::interop::Response<libnss::group::Group> {
-        let mut cl = RPC.lock().unwrap();
-        cl.with_client(|client| {
-            match block_on(client.get_group_by_name(context::current(), name)) {
-                Ok(passwd) => match passwd {
-                    Some(p) => Response::Success(p.to_nss()),
-                    None => Response::NotFound,
-                },
-                Err(_e) => Response::Unavail,
-            }
-        })
-    }
-}
-
-use libnss::passwd::PasswdHooks;
-#[no_mangle]
-extern "C" fn _nss_simpleauthd_setpwent() -> c_int {
-    let mut iter: MutexGuard<Iterator<Passwd>> = PASSWD_ITERATOR.lock().unwrap();
-
-    let status = match CauthdPasswd::get_all_entries() {
-        Response::Success(entries) => iter.open(entries),
-        response => response.to_status(),
-    };
-
-    status as c_int
-}
-
-#[no_mangle]
-extern "C" fn _nss_simpleauthd_endpwent() -> c_int {
-    let mut iter: MutexGuard<Iterator<Passwd>> = PASSWD_ITERATOR.lock().unwrap();
-    iter.close() as c_int
-}
-
-#[no_mangle]
-unsafe extern "C" fn _nss_simpleauthd_getpwent_r(
-    result: *mut CPasswd,
-    buf: *mut libc::c_char,
-    buflen: libc::size_t,
-    errnop: *mut c_int,
-) -> c_int {
-    let mut iter: MutexGuard<Iterator<Passwd>> = PASSWD_ITERATOR.lock().unwrap();
-    iter.next().to_c(result, buf, buflen, errnop) as c_int
-}
-
-#[no_mangle]
-unsafe extern "C" fn _nss_simpleauthd_getpwuid_r(
-    uid: libc::uid_t,
-    result: *mut CPasswd,
-    buf: *mut libc::c_char,
-    buflen: libc::size_t,
-    errnop: *mut c_int,
-) -> c_int {
-    CauthdPasswd::get_entry_by_uid(uid).to_c(result, buf, buflen, errnop) as c_int
-}
-
-#[no_mangle]
-unsafe extern "C" fn nss_simpleauthd_getpwnam_r(
-    name_: *const libc::c_char,
-    result: *mut CPasswd,
-    buf: *mut libc::c_char,
-    buflen: libc::size_t,
-    errnop: *mut c_int,
-) -> c_int {
-    let cstr = CStr::from_ptr(name_);
-
-    let response = match str::from_utf8(cstr.to_bytes()) {
-        Ok(name) => CauthdPasswd::get_entry_by_name(name.to_string()),
-        Err(_) => Response::NotFound,
-    };
-
-    response.to_c(result, buf, buflen, errnop) as c_int
-}
-#[no_mangle]
-extern "C" fn _nss_simpleauthd_setgrent() -> c_int {
-    let mut iter: MutexGuard<Iterator<Group>> = GROUP_ITERATOR.lock().unwrap();
-
-    let status = match CauthdGroup::get_all_entries() {
-        Response::Success(entries) => iter.open(entries),
-        response => response.to_status(),
-    };
-
-    status as c_int
-}
-
-#[no_mangle]
-extern "C" fn _nss_simpleauthd_endgrent() -> c_int {
-    let mut iter: MutexGuard<Iterator<Group>> = GROUP_ITERATOR.lock().unwrap();
-    iter.close() as c_int
-}
-
-#[no_mangle]
-unsafe extern "C" fn _nss_simpleauthd_getgrent_r(
-    result: *mut CGroup,
-    buf: *mut libc::c_char,
-    buflen: libc::size_t,
-    errnop: *mut c_int,
-) -> c_int {
-    let mut iter: MutexGuard<Iterator<Group>> = GROUP_ITERATOR.lock().unwrap();
-    iter.next().to_c(result, buf, buflen, errnop) as c_int
-}
-
-#[no_mangle]
-unsafe extern "C" fn _nss_simpleauthd_getgrgid_r(
-    uid: libc::uid_t,
-    result: *mut CGroup,
-    buf: *mut libc::c_char,
-    buflen: libc::size_t,
-    errnop: *mut c_int,
-) -> c_int {
-    CauthdGroup::get_entry_by_gid(uid).to_c(result, buf, buflen, errnop) as c_int
-}
-
-#[no_mangle]
-unsafe extern "C" fn nss_simpleauthd_getgrnam_r(
-    name_: *const libc::c_char,
-    result: *mut CGroup,
-    buf: *mut libc::c_char,
-    buflen: libc::size_t,
-    errnop: *mut c_int,
-) -> c_int {
-    let cstr = CStr::from_ptr(name_);
-
-    let response = match str::from_utf8(cstr.to_bytes()) {
-        Ok(name) => CauthdGroup::get_entry_by_name(name.to_string()),
-        Err(_) => Response::NotFound,
-    };
-
-    response.to_c(result, buf, buflen, errnop) as c_int
-}
-
-use libnss::shadow::{CShadow, Shadow, ShadowHooks};
-
-#[no_mangle]
-extern "C" fn _nss_simpleauthd_setspent() -> c_int {
-    let mut iter: MutexGuard<Iterator<Shadow>> = SHADOW_ITERATOR.lock().unwrap();
-
-    let status = match CauthdShadow::get_all_entries() {
-        Response::Success(entries) => iter.open(entries),
-        response => response.to_status(),
-    };
-
-    status as c_int
-}
-
-#[no_mangle]
-extern "C" fn _nss_simpleauthd_endspent() -> c_int {
-    let mut iter: MutexGuard<Iterator<Shadow>> = SHADOW_ITERATOR.lock().unwrap();
-    iter.close() as c_int
-}
-
-#[no_mangle]
-unsafe extern "C" fn _nss_simpleauthd_getspent_r(
-    result: *mut CShadow,
-    buf: *mut libc::c_char,
-    buflen: libc::size_t,
-    errnop: *mut c_int,
-) -> c_int {
-    let mut iter: MutexGuard<Iterator<Shadow>> = SHADOW_ITERATOR.lock().unwrap();
-    iter.next().to_c(result, buf, buflen, errnop) as c_int
-}
-
-#[no_mangle]
-unsafe extern "C" fn nss_simpleauthd_getspnam_r(
-    name_: *const libc::c_char,
-    result: *mut CShadow,
-    buf: *mut libc::c_char,
-    buflen: libc::size_t,
-    errnop: *mut c_int,
-) -> c_int {
-    let cstr = CStr::from_ptr(name_);
-
-    let response = match str::from_utf8(cstr.to_bytes()) {
-        Ok(name) => CauthdShadow::get_entry_by_name(name.to_string()),
-        Err(_) => Response::NotFound,
-    };
-
-    response.to_c(result, buf, buflen, errnop) as c_int
 }

--- a/nss_simpleauthd/src/passwd.rs
+++ b/nss_simpleauthd/src/passwd.rs
@@ -1,0 +1,47 @@
+use authd::types::ToNSS;
+use futures::executor::block_on;
+use libnss::{
+    interop::Response,
+    passwd::{Passwd, PasswdHooks},
+};
+use tarpc::context;
+
+use crate::{AuthdPasswd, RPC};
+
+impl PasswdHooks for AuthdPasswd {
+    fn get_all_entries() -> Response<Vec<Passwd>> {
+        let mut cl = RPC.lock().unwrap();
+        cl.with_client(
+            |client| match block_on(client.get_all_passwd(context::current())) {
+                Ok(passwds) => Response::Success(passwds.into_iter().map(|x| x.to_nss()).collect()),
+                Err(_e) => Response::Unavail,
+            },
+        )
+    }
+
+    fn get_entry_by_uid(uid: libc::uid_t) -> Response<Passwd> {
+        let mut cl = RPC.lock().unwrap();
+        cl.with_client(
+            |client| match block_on(client.get_passwd_by_uid(context::current(), uid)) {
+                Ok(passwd) => match passwd {
+                    Some(p) => Response::Success(p.to_nss()),
+                    None => Response::NotFound,
+                },
+                Err(_e) => Response::Unavail,
+            },
+        )
+    }
+
+    fn get_entry_by_name(name: String) -> Response<Passwd> {
+        let mut cl = RPC.lock().unwrap();
+        cl.with_client(|client| {
+            match block_on(client.get_passwd_by_name(context::current(), name)) {
+                Ok(passwd) => match passwd {
+                    Some(p) => Response::Success(p.to_nss()),
+                    None => Response::NotFound,
+                },
+                Err(_e) => Response::Unavail,
+            }
+        })
+    }
+}

--- a/nss_simpleauthd/src/shadow.rs
+++ b/nss_simpleauthd/src/shadow.rs
@@ -1,0 +1,34 @@
+use authd::types::ToNSS;
+use futures::executor::block_on;
+use libnss::{
+    interop::Response,
+    shadow::{Shadow, ShadowHooks},
+};
+use tarpc::context;
+
+use crate::{AuthdShadow, RPC};
+
+impl ShadowHooks for AuthdShadow {
+    fn get_all_entries() -> Response<Vec<Shadow>> {
+        let mut cl = RPC.lock().unwrap();
+        cl.with_client(
+            |client| match block_on(client.get_all_shadow(context::current())) {
+                Ok(passwds) => Response::Success(passwds.into_iter().map(|x| x.to_nss()).collect()),
+                Err(_e) => Response::Unavail,
+            },
+        )
+    }
+
+    fn get_entry_by_name(name: String) -> libnss::interop::Response<libnss::shadow::Shadow> {
+        let mut cl = RPC.lock().unwrap();
+        cl.with_client(|client| {
+            match block_on(client.get_shadow_by_name(context::current(), name)) {
+                Ok(passwd) => match passwd {
+                    Some(p) => Response::Success(p.to_nss()),
+                    None => Response::NotFound,
+                },
+                Err(_e) => Response::Unavail,
+            }
+        })
+    }
+}


### PR DESCRIPTION
We seem to be stick with `libnss` and unrolling the macros ourselves. I figure this code needed to be "cleaned up" a bit, this PR refactors `nss_simpleauthd` from 1 large file into many, logically organized, files.